### PR TITLE
public API: export detect_arch and load_tokenizer_from_gguf (tokenizer-only entry points)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project aims to
 adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `detect_arch` and `load_tokenizer_from_gguf` promoted to the stable public
+  API (`gmlx.__all__`): synthesize the HF tokenizer from GGUF metadata without
+  loading the model. Consumed by mlx-kld's `[gguf]` scoring extra for
+  tokenizer parity checks ahead of the model load.
+
 ## [0.1.0] - 2026-07-19
 
 First public release: a local inference platform for Apple Silicon that runs

--- a/docs/python.md
+++ b/docs/python.md
@@ -139,6 +139,30 @@ Failures raise one of two exceptions, from `preflight` or `load_model` alike:
 `backend`). [arch-coverage.md](arch-coverage.md) is the generated
 human-readable view of the same data, with validation status.
 
+## Tokenizer without the model
+
+```python
+from gguf import GGUFReader
+from gmlx import detect_arch, load_tokenizer_from_gguf
+
+reader = GGUFReader("model.gguf", "r")
+arch = detect_arch(reader)
+tokenizer = load_tokenizer_from_gguf(reader, arch)
+```
+
+`load_tokenizer_from_gguf(meta, arch, *, chat_template_override=None)` builds
+an HF fast tokenizer purely from the GGUF's embedded vocab/merges/scores
+metadata - the same synthesis `load_model` runs internally - without paying
+the model load. `detect_arch(reader)` reads `general.architecture` from the
+header. Both read only GGUF metadata, so they stay cheap on multi-GB files.
+
+Use these when a tool needs the tokenizer before deciding whether to load
+weights at all: eval harnesses doing tokenizer parity checks (mlx-kld's
+GGUF scoring), corpus pre-tokenization, or template inspection.
+`chat_template_override` (an inline Jinja string) replaces the GGUF's chat
+template and is applied before multi-EOS inference, so EOS detection runs
+against the override.
+
 ## mlx-lm server bridge
 
 ```python

--- a/gmlx/__init__.py
+++ b/gmlx/__init__.py
@@ -37,6 +37,11 @@ _EXPORTS = {
     "KQuantMultiLinear": "modules",
     "install_kquant_modules": "modules",
     "install_gguf_bridge": "server_bridge_lm",
+    # Tokenizer-only entry points: synthesize the HF tokenizer from GGUF
+    # metadata without paying the model load. Used by eval tooling (mlx-kld)
+    # that needs tokenizer parity checks before deciding to load weights.
+    "detect_arch": "remap",
+    "load_tokenizer_from_gguf": "tokenizer",
 }
 
 __all__ = list(_EXPORTS)

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -79,14 +79,20 @@ def test_exit_joins_thread_on_exception():
 
 def test_println_on_tty_clears_frame_and_emits_line():
     buf = _FakeTTY()
+    def frame_after_line() -> bool:
+        parts = buf.getvalue().split("WARNING: odd tensor\n", 1)
+        return len(parts) == 2 and any(f in parts[1] for f in spinner._FRAMES)
+
     with spinner.Spinner("loading", stream=buf) as s:
         time.sleep(0.12)
         s.println("WARNING: odd tensor")
-        time.sleep(0.12)                         # animation resumes after
+        deadline = time.monotonic() + 5.0        # wait for animation to resume,
+        while not frame_after_line():            # don't guess scheduling latency
+            assert time.monotonic() < deadline, "no frame after println"
+            time.sleep(0.01)
     out = buf.getvalue()
     assert "\r\x1b[KWARNING: odd tensor\n" in out
-    after = out.split("WARNING: odd tensor\n", 1)[1]
-    assert any(f in after for f in spinner._FRAMES)   # frames landed after the line
+    assert frame_after_line()                    # frames landed after the line
 
 
 def test_println_off_tty_is_plain_line():


### PR DESCRIPTION
- API to synthesize an HF tokenizer from GGUF metadata without loading the model