### PR TITLE
dsv32: stock gather decode now on by default, mask path remains as opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- glm-dsa/DeepSeek-V3.2 sparse decode uses the stock top-k gather again
+  (O(index_topk) per step); the mask-path workaround is now opt-in via
+  `GMLX_DSV32_MASK_DECODE=1`.
+
 ## [0.1.4] - 2026-07-27
 
 ### Added

--- a/gmlx/dsv32_patches.py
+++ b/gmlx/dsv32_patches.py
@@ -16,23 +16,23 @@ from .envflags import env_bool, env_int
 from .patching import ClassPatch
 
 
-# DeepSeek-V3.2 / glm-dsa: mask-path decode attention (correctness patch)
+# DeepSeek-V3.2 / glm-dsa: mask-path decode attention (opt-in mitigation)
 #
 # mlx-lm's DeepseekV32Attention applies the DSA "lightning indexer" top-k by
 # gathering the selected keys on the L==1 decode step, but by masking full keys
-# on the L>1 prefill step. The gather is mathematically equivalent to the mask
-# (verified ~bit-for-bit at small scale) yet corrupts the decode attention
-# *distribution* once context exceeds index_topk (~2048): the argmax stays right
-# (greedy looks fine) while the tail is wrong, so temperature/top-p sampling
-# degenerates to token-garbage at depth. llama.cpp and mlx-lm's own prefill both
-# take the mask path and stay coherent.
+# on the L>1 prefill step. An early stack corrupted the decode distribution on
+# the gather path past index_topk depth, and this patch (mask every L, never
+# gather) shipped as the fix. Re-tested 2026-07: the corruption does not
+# reproduce - gathers are bit-exact to S=32k on synthetic and real modules on
+# both devices, and a live GLM-5.2 A/B at depth against a bit-identical replay
+# control shows only bf16-rounding-scale divergence between the two paths. The
+# stock gather is therefore the default again: it keeps decode attention
+# O(index_topk) instead of O(context).
 #
-# This routes the L==1 decode step through that same mask path. The body is the
-# exact upstream forward with only the `if topk_indices is not None` block changed
-# to always mask (never gather). Trade-off: decode attention becomes O(context)
-# rather than O(index_topk) - negligible for over-RAM streaming (decode is
-# disk-bound) but it forfeits DSA's sparse-decode speedup for long-context in-RAM
-# use. Kill with GMLX_DSV32_MASK_DECODE=0.
+# The mask path is retained as an opt-in mitigation (GMLX_DSV32_MASK_DECODE=1)
+# in case a gather-side regression ever resurfaces. The body is the exact
+# upstream forward with only the `if topk_indices is not None` block changed
+# to always mask.
 _MASK_DECODE_PATCH = ClassPatch()
 
 
@@ -117,8 +117,9 @@ def _patch_dsv32_mask_decode(model) -> None:
     attention module in ``model``. Installs the class-level dispatch once (a no-op
     for any instance without the per-instance ``_dsv32_mask_decode`` flag, so
     unrelated loads in the same process are untouched) and flags this model's
-    instances. Kill with GMLX_DSV32_MASK_DECODE=0."""
-    if not env_bool("GMLX_DSV32_MASK_DECODE", True):
+    instances. Off by default (stock gather decode); opt in with
+    GMLX_DSV32_MASK_DECODE=1."""
+    if not env_bool("GMLX_DSV32_MASK_DECODE", False):
         return
     from mlx_lm.models.deepseek_v32 import DeepseekV32Attention
 

--- a/gmlx/loader.py
+++ b/gmlx/loader.py
@@ -2876,9 +2876,10 @@ def load_model(
     #         sink+local (GMLX_DSV32_SINK/_LOCAL). Why our score diverges from
     #         llama (which keeps them via score alone) is unresolved; sparse stays
     #         experimental and dense is the default.
-    #       (secondary) the L==1 decode applies the top-k by gathering keys rather
-    #         than masking, corrupting the sampling tail. Kill with
-    #         GMLX_DSV32_MASK_DECODE=0.
+    #       (secondary, retired default) the L==1 gather decode was suspected of
+    #         corrupting the sampling tail on an early stack; re-tested clean, so
+    #         stock gather is the default. GMLX_DSV32_MASK_DECODE=1 re-arms the
+    #         mask-path mitigation.
     if config.get("model_type") in ("glm_moe_dsa", "deepseek_v32"):
         _patch_dsv32_indexer_rope(model)
         _patch_dsv32_indexer_fp32(model)

--- a/tests/test_dsv32_mask_decode.py
+++ b/tests/test_dsv32_mask_decode.py
@@ -1,21 +1,18 @@
-"""Regression test for the glm-dsa / DeepSeek-V3.2 decode correctness patch
+"""Regression test for the glm-dsa / DeepSeek-V3.2 mask-path decode mitigation
 (``dsv32_patches._patch_dsv32_mask_decode``).
 
 mlx-lm's ``DeepseekV32Attention`` applies the DSA indexer top-k by GATHERING keys on
-the L==1 decode step but MASKING full keys on the L>1 prefill step. The gather is
-gather-equivalent to the mask at small scale yet corrupts the decode attention tail
-once context exceeds ``index_topk`` (~2048), so temperature/top-p sampling degenerates
-at depth while greedy stays fine. The patch routes the L==1 decode step through the
-mask path too.
+the L==1 decode step but MASKING full keys on the L>1 prefill step. The mask path
+shipped as a corruption fix on an early stack; the corruption no longer reproduces,
+so stock gather is the default and the mask path is an opt-in mitigation
+(``GMLX_DSV32_MASK_DECODE=1``).
 
-No GGUF / no GPU: builds a tiny random-weight stock ``glm_moe_dsa`` model and checks the
-patch (1) installs + flags every attention module, (2) reproduces the stock decode
-logits at small scale (where gather == mask - guards the mask rewrite), exercising the
-indexer's sparse branch, (3) honours the ``GMLX_DSV32_MASK_DECODE=0`` kill-switch,
-and (4) leaves unflagged instances on the stock path.
+No GGUF / no GPU: builds a tiny random-weight stock ``glm_moe_dsa`` model and checks
+(1) the opt-in installs + flags every attention module, (2) the mask rewrite
+reproduces the stock decode logits at small scale, exercising the indexer's sparse
+branch, (3) the default and an explicit ``0`` both leave the model on stock gather,
+and (4) unflagged instances stay on the stock path even with the class patched.
 """
-
-import os
 
 import mlx.core as mx
 import pytest
@@ -95,7 +92,8 @@ def _n_attn(model: Model) -> int:
     return sum(isinstance(m, DeepseekV32Attention) for m in model.modules())
 
 
-def test_patch_installs_and_flags_every_attention():
+def test_patch_installs_and_flags_every_attention(monkeypatch):
+    monkeypatch.setenv("GMLX_DSV32_MASK_DECODE", "1")
     model = _build()
     n_attn = _n_attn(model)
     assert n_attn > 0
@@ -112,7 +110,8 @@ def test_patch_installs_and_flags_every_attention():
     assert flagged == n_attn
 
 
-def test_mask_decode_matches_stock_gather_at_small_scale():
+def test_mask_decode_matches_stock_gather_at_small_scale(monkeypatch):
+    monkeypatch.setenv("GMLX_DSV32_MASK_DECODE", "1")
     # index_topk small + prefill above it -> sparse indexer branch fires every step.
     prefill, n = 6, 5
     model = _build(index_topk=4)
@@ -132,18 +131,11 @@ def test_mask_decode_matches_stock_gather_at_small_scale():
     assert bool(mx.all(mx.argmax(fixed, -1) == mx.argmax(stock, -1)).item())
 
 
-def test_kill_switch_skips_patch():
+def test_default_off_skips_patch(monkeypatch):
+    # Stock gather decode is the default; the mask path is opt-in.
+    monkeypatch.delenv("GMLX_DSV32_MASK_DECODE", raising=False)
     model = _build()
-    prev = os.environ.get("GMLX_DSV32_MASK_DECODE")
-    os.environ["GMLX_DSV32_MASK_DECODE"] = "0"
-    try:
-        dsv32_patches._patch_dsv32_mask_decode(model)
-    finally:
-        if prev is None:
-            os.environ.pop("GMLX_DSV32_MASK_DECODE", None)
-        else:
-            os.environ["GMLX_DSV32_MASK_DECODE"] = prev
-    # No instance on this model should have been flagged.
+    dsv32_patches._patch_dsv32_mask_decode(model)
     assert not any(
         getattr(m, "_dsv32_mask_decode", False)
         for m in model.modules()
@@ -151,10 +143,22 @@ def test_kill_switch_skips_patch():
     )
 
 
-def test_unflagged_instance_uses_stock_path():
+def test_explicit_zero_skips_patch(monkeypatch):
+    monkeypatch.setenv("GMLX_DSV32_MASK_DECODE", "0")
+    model = _build()
+    dsv32_patches._patch_dsv32_mask_decode(model)
+    assert not any(
+        getattr(m, "_dsv32_mask_decode", False)
+        for m in model.modules()
+        if isinstance(m, DeepseekV32Attention)
+    )
+
+
+def test_unflagged_instance_uses_stock_path(monkeypatch):
     # Even with the class patch installed, an unflagged instance must hit the stock
     # fallback. Compare an all-unflagged model's decode to the saved stock call run
     # directly on the same modules.
+    monkeypatch.setenv("GMLX_DSV32_MASK_DECODE", "1")
     model = _build(index_topk=4)
     dsv32_patches._patch_dsv32_mask_decode(model)  # ensure class is patched
     for m in model.modules():

--- a/tests/test_envflags.py
+++ b/tests/test_envflags.py
@@ -295,8 +295,6 @@ def test_gdn_zba_default_off_and_opt_in(monkeypatch):
 
 _DSV32_KILL_SITES = [
     # (env name, patch fn, ClassPatch global, patched class)
-    ("GMLX_DSV32_MASK_DECODE", "_patch_dsv32_mask_decode",
-     "_MASK_DECODE_PATCH", "DeepseekV32Attention"),
     ("GMLX_DSV32_INDEXER_ROPE", "_patch_dsv32_indexer_rope", None, None),
     ("GMLX_DSV32_INDEXER_FP32", "_patch_dsv32_indexer_fp32",
      "_INDEXER_FP32_PATCH", "Indexer"),
@@ -331,6 +329,28 @@ def test_dsv32_kill_switches(monkeypatch, name, fn, flag, clsname):
             cls.__call__ = saved_call
         if cp:
             cp.installed = saved_installed
+
+
+def test_dsv32_mask_decode_opt_in(monkeypatch):
+    # Inverted default: stock gather decode by default, mask path opt-in.
+    patches = importlib.import_module("gmlx.dsv32_patches")
+    dsv32 = importlib.import_module("mlx_lm.models.deepseek_v32")
+    cp = patches._MASK_DECODE_PATCH
+    saved_call = dsv32.DeepseekV32Attention.__call__
+    saved_installed = cp.installed
+    cp.installed = False
+    try:
+        # default (unset): returns before touching the model
+        monkeypatch.delenv("GMLX_DSV32_MASK_DECODE", raising=False)
+        patches._patch_dsv32_mask_decode(_BoomModules())
+        assert cp.installed is False
+        # opt-in: reaches the model walk
+        monkeypatch.setenv("GMLX_DSV32_MASK_DECODE", "1")
+        with pytest.raises(_Boom):
+            patches._patch_dsv32_mask_decode(_BoomModules())
+    finally:
+        dsv32.DeepseekV32Attention.__call__ = saved_call
+        cp.installed = saved_installed
 
 
 def test_dsv32_sparse_opt_in(monkeypatch):


### PR DESCRIPTION
- the mask path was a workaround for a correctness bug in the original dsv32 gather implementation. now that it's fixed, flipping the default back to stock gives constant time attention decode