### PR TITLE
perf(serve): quantized-KV prefill and decode take the fused kq paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           pip install "mlx==0.31.2"
           # 0.3.7 is the first release with a cp314 wheel; below it the 3.14 job
           # compiles the Metal extension from sdist.
-          pip install "mlx-kquant>=0.3.7"
+          pip install "mlx-kquant>=0.3.8"
           # `assistant` pulls the MCP SDK: without it the stdio tool-server
           # tests (env isolation especially) importorskip themselves away.
           pip install -e ".[vlm,chat,assistant]" pytest httpx build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,6 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   retain the reply up to the divergence point (`GMLX_APC_DECODE_CKPT`,
   default 512 generated tokens; `0` off).
 
-### Changed
-
-- glm-dsa/DeepSeek-V3.2 sparse decode uses the stock top-k gather again
-  (O(index_topk) per step); the mask-path workaround is now opt-in via
-  `GMLX_DSV32_MASK_DECODE=1`.
-- The server's APC prompt-cache manager is now gmlx-owned, built at model
-  load; config `cache.enabled` and a plain `APC_ENABLED=1` both keep working.
-
 ### Fixed
 
 - Non-stream replies that hit `max_tokens` inside a think block now return
@@ -46,8 +38,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   checkpoints on GDN models no longer write recurrent state to disk.
 - A finished request's retirement-key memo no longer pins the response
   generator (and its model weights) past a pool unload.
+- Quantized-KV (`kv_bits`) prefill no longer runs 1.6-1.9x slower than
+  fp16: prefill-width attention now takes the fused flash path
+  (`GMLX_KV8_PREFILL_FLASH=0` restores the old behavior).
 
 ### Changed
+
+- glm-dsa/DeepSeek-V3.2 sparse decode uses the stock top-k gather again
+  (O(index_topk) per step); the mask-path workaround is now opt-in via
+  `GMLX_DSV32_MASK_DECODE=1`.
+- The server's APC prompt-cache manager is now gmlx-owned, built at model
+  load; config `cache.enabled` and a plain `APC_ENABLED=1` both keep working.
 
 - gemma-4 batched decode runs the global (hd512) layers as one ragged
   kernel call per layer instead of a per-row loop (needs mlx-kquant with
@@ -57,11 +58,9 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   construction (`GMLX_GEMMA_OWNED=0` reverts to the stock classes plus the
   patch regime; numerics identical either way).
 
-### Fixed
-
-- Quantized-KV (`kv_bits`) prefill no longer runs 1.6-1.9x slower than
-  fp16: prefill-width attention now takes the fused flash path
-  (`GMLX_KV8_PREFILL_FLASH=0` restores the old behavior).
+- Quantized-KV (`kv_bits: 8`) decode routes through the fused mlx_kquant
+  kernel when available, ~1.4x per attention call at depth
+  (`GMLX_QSDPA_KQ=0` restores the stock path).
 
 ## [0.1.4] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   construction (`GMLX_GEMMA_OWNED=0` reverts to the stock classes plus the
   patch regime; numerics identical either way).
 
+### Fixed
+
+- Quantized-KV (`kv_bits`) prefill no longer runs 1.6-1.9x slower than
+  fp16: prefill-width attention now takes the fused flash path
+  (`GMLX_KV8_PREFILL_FLASH=0` restores the old behavior).
+
 ## [0.1.4] - 2026-07-27
 
 ### Added

--- a/gmlx/quantized_sdpa_fix.py
+++ b/gmlx/quantized_sdpa_fix.py
@@ -1,30 +1,43 @@
-"""Upstream-bug fix: quantized-KV SDPA mask broadcast at B>1 with GQA.
+"""Quantized-KV SDPA fixes at both base-module seams.
 
 Both mlx_lm.models.base and mlx_vlm.models.base carry the same
-quantized_scaled_dot_product_attention: when n_repeats > 1 it reshapes
-queries to the grouped 5D layout (B, n_kv_heads, n_repeats, L, D), so the
-score tensor is 5D -- but an array mask is applied as-is. A batched
+quantized_scaled_dot_product_attention. Two independent problems live
+there, patched by one wrapper:
+
+Mask broadcast at B>1 with GQA (upstream bug): when n_repeats > 1 it
+reshapes queries to the grouped 5D layout (B, n_kv_heads, n_repeats, L, D),
+so the score tensor is 5D -- but an array mask is applied as-is. A batched
 left-pad mask (B, 1, 1, kv) left-pads to (1, B, 1, 1, kv) under broadcast,
 its batch dim lands in the n_kv_heads slot, and the mx.where raises a
 broadcast error. Every batched (B>1) masked GQA call with a quantized KV
 cache crashes; B=1 works because a leading 1 broadcasts anywhere, which is
-why single-stream kv4/kv8 measurements never saw it.
+why single-stream kv4/kv8 measurements never saw it. The fix inserts one
+axis: a 4D array mask becomes (B, 1, 1, L, kv) before the wrapped call
+whenever the call is grouped. Masks without a real batch dim
+((1, 1, L, kv), 2D, "causal", None) are unchanged in effect -- the expand
+is a no-op under broadcasting -- so the wrapper applies it to every 4D
+array mask rather than sniffing shapes.
 
-The fix inserts one axis: a 4D array mask becomes (B, 1, 1, L, kv) before
-the wrapped call whenever the call is grouped. Masks without a real batch
-dim ((1, 1, L, kv), 2D, "causal", None) are unchanged in effect -- the
-expand is a no-op under broadcasting -- so the wrapper applies it to every
-4D array mask rather than sniffing shapes.
+Prefill-width flash path (perf): the stock body runs two unfused
+mx.quantized_matmul passes plus a separate masked softmax. At decode
+width (qL == 1) that is at parity with the fused fp16 path, but at
+prefill chunk widths it is 3.4-4.2x slower per call, which put
+``kv_bits: 8`` serving 1.6-1.9x behind fp16 on prefill wall time. When
+the query width reaches GMLX_KV8_PREFILL_FLASH_MIN_L (default 8) the
+wrapper dequantizes the K/V wire once (a bandwidth-bound copy, amortized
+over the chunk) and runs fused mx.fast.scaled_dot_product_attention
+instead; grouping never happens on that path, so the mask needs no
+reshaping. Kill with GMLX_KV8_PREFILL_FLASH=0.
 
-Install is idempotent; GMLX_QSDPA_MASK_FIX=0 disables. Patched at each
-base module's symbol (their scaled_dot_product_attention dispatchers read
-the module global at call time).
+Install is idempotent; GMLX_QSDPA_MASK_FIX=0 disables the whole wrapper.
+Patched at each base module's symbol (their scaled_dot_product_attention
+dispatchers read the module global at call time).
 """
 from __future__ import annotations
 
 import mlx.core as mx
 
-from .envflags import env_bool
+from .envflags import env_bool, env_int
 
 _installed = False
 
@@ -34,6 +47,15 @@ _MODULES = ("mlx_lm.models.base", "mlx_vlm.models.base")
 def _make_fixed(orig):
     def _masked_grouped_qsdpa(queries, q_keys, q_values, scale, mask,
                               group_size: int = 64, bits: int = 8):
+        if (
+            queries.shape[-2] >= env_int("GMLX_KV8_PREFILL_FLASH_MIN_L", 8)
+            and env_bool("GMLX_KV8_PREFILL_FLASH", True)
+        ):
+            keys = mx.dequantize(*q_keys, group_size=group_size, bits=bits)
+            values = mx.dequantize(*q_values, group_size=group_size,
+                                   bits=bits)
+            return mx.fast.scaled_dot_product_attention(
+                queries, keys, values, scale=scale, mask=mask)
         if (
             isinstance(mask, mx.array)
             and mask.ndim == 4

--- a/gmlx/quantized_sdpa_fix.py
+++ b/gmlx/quantized_sdpa_fix.py
@@ -1,7 +1,7 @@
 """Quantized-KV SDPA fixes at both base-module seams.
 
 Both mlx_lm.models.base and mlx_vlm.models.base carry the same
-quantized_scaled_dot_product_attention. Two independent problems live
+quantized_scaled_dot_product_attention. Three independent problems live
 there, patched by one wrapper:
 
 Mask broadcast at B>1 with GQA (upstream bug): when n_repeats > 1 it
@@ -29,11 +29,31 @@ over the chunk) and runs fused mx.fast.scaled_dot_product_attention
 instead; grouping never happens on that path, so the mask needs no
 reshaping. Kill with GMLX_KV8_PREFILL_FLASH=0.
 
+Fused decode route (perf): at qL == 1 the stock body is correct and at
+parity with fp16, but when the mlx_kquant build carries quantized-KV
+operands on sdpa_decode_gqa (dequant fused into the staged K/V walk,
+one online-softmax dispatch) the same call runs ~1.4x faster at depth.
+Decode-shaped calls (qL == 1, group 64 / bits 8, hd 64-512, gqa <= 16)
+route there. Serving batches carry a boolean left-pad mask; the kernel
+wants per-row ``starts`` instead, and the conversion must not inspect
+mask CONTENTS -- a data-dependent check is a GPU sync, and under paced
+serving that sync lands behind whole in-flight prefill chunks on the
+in-order queue, stalling decode enough that the pacing loop throttles
+prefill admission into a spiral (measured: agg 54.5 -> 40.5). Instead
+the route trusts mask PROVENANCE: BatchQuantizedKVCache.make_mask is
+patched to register each mask it creates against the cache's
+left_padding (python-held row pads -- exactly the kernel's starts), and
+the wrapper routes only masks found in that registry. Unregistered
+array masks fall back to the stock body untouched. Kill with
+GMLX_QSDPA_KQ=0.
+
 Install is idempotent; GMLX_QSDPA_MASK_FIX=0 disables the whole wrapper.
 Patched at each base module's symbol (their scaled_dot_product_attention
 dispatchers read the module global at call time).
 """
 from __future__ import annotations
+
+import collections
 
 import mlx.core as mx
 
@@ -43,8 +63,76 @@ _installed = False
 
 _MODULES = ("mlx_lm.models.base", "mlx_vlm.models.base")
 
+_HD_OK = (64, 128, 256, 512)
 
-def _make_fixed(orig):
+# id -> (mask object, starts array). Populated by the patched
+# BatchQuantizedKVCache.make_mask; the mask object is pinned so its id
+# cannot be recycled while the entry lives. All layers of a step share
+# one mask object, so lookups after the first are dict hits.
+_STARTS_MEMO: collections.OrderedDict = collections.OrderedDict()
+_STARTS_MEMO_CAP = 8
+
+
+def _kq_q8_route():
+    """The fused-route callable, or None when unavailable."""
+    try:
+        import mlx_kquant as kq
+    except ImportError:
+        return None
+    fn = getattr(kq, "sdpa_decode_gqa", None)
+    doc = (getattr(fn, "__doc__", "") or "") if fn is not None else ""
+    if "k_scales" not in doc or "starts" not in doc:
+        return None
+    return fn
+
+
+def _register_starts(mask, left_padding):
+    """Record a mask's per-row starts at its creation site. No syncs:
+    left_padding is the creator's python-held pad state, taken on trust."""
+    _STARTS_MEMO[id(mask)] = (mask, left_padding.astype(mx.int32))
+    if len(_STARTS_MEMO) > _STARTS_MEMO_CAP:
+        _STARTS_MEMO.popitem(last=False)
+
+
+def _registered_starts(mask):
+    """Starts registered for this exact mask object, else None."""
+    ent = _STARTS_MEMO.get(id(mask))
+    if ent is not None and ent[0] is mask:
+        return ent[1]
+    return None
+
+
+def _patch_make_mask() -> bool:
+    """Register left-pad decode masks as BatchQuantizedKVCache creates
+    them. Plain causal+left-pad masks only: windowed or right-padded
+    calls pass through unregistered (their masks are not pure left-pad,
+    and the stock body handles them)."""
+    try:
+        from mlx_vlm.models.cache import BatchQuantizedKVCache
+    except ImportError:
+        return False
+    orig = BatchQuantizedKVCache.make_mask
+    if getattr(orig, "_gmlx_starts_reg", False):
+        return True
+
+    def make_mask(self, N, return_array=False, **kwargs):
+        mask = orig(self, N, return_array=return_array, **kwargs)
+        if (
+            N == 1
+            and isinstance(mask, mx.array)
+            and mask.dtype == mx.bool_
+            and not any(v is not None for v in kwargs.values())
+        ):
+            _register_starts(mask, self.left_padding)
+        return mask
+
+    make_mask._gmlx_starts_reg = True
+    make_mask._gmlx_orig = orig
+    BatchQuantizedKVCache.make_mask = make_mask
+    return True
+
+
+def _make_fixed(orig, kq_fn):
     def _masked_grouped_qsdpa(queries, q_keys, q_values, scale, mask,
                               group_size: int = 64, bits: int = 8):
         if (
@@ -56,6 +144,41 @@ def _make_fixed(orig):
                                    bits=bits)
             return mx.fast.scaled_dot_product_attention(
                 queries, keys, values, scale=scale, mask=mask)
+        if (
+            kq_fn is not None
+            and env_bool("GMLX_QSDPA_KQ", True)
+            and group_size == 64
+            and bits == 8
+            and queries.ndim == 4
+            and queries.shape[2] == 1
+            and queries.shape[3] in _HD_OK
+            and queries.dtype in (mx.float16, mx.bfloat16)
+            and queries.shape[1] % q_keys[0].shape[1] == 0
+            and 1 <= queries.shape[1] // q_keys[0].shape[1] <= 16
+        ):
+            starts = None
+            routable = not isinstance(mask, mx.array)
+            if (
+                not routable
+                and mask.dtype == mx.bool_
+                and mask.ndim == 4
+                and mask.shape[0] == queries.shape[0]
+                and mask.shape[1] == 1
+                and mask.shape[2] == 1
+                and mask.shape[3] == q_keys[0].shape[2]
+            ):
+                starts = _registered_starts(mask)
+                routable = starts is not None
+            if routable:
+                try:
+                    kw, ks, kb = q_keys
+                    vw, vs, vb = q_values
+                    return kq_fn(
+                        queries, kw, vw, float(scale), starts=starts,
+                        k_scales=ks, k_biases=kb,
+                        v_scales=vs, v_biases=vb)
+                except Exception:
+                    pass  # any unsupported layout -> stock fallback
         if (
             isinstance(mask, mx.array)
             and mask.ndim == 4
@@ -82,6 +205,9 @@ def install_quantized_sdpa_mask_fix() -> bool:
         return True
     import importlib
 
+    kq_fn = _kq_q8_route()
+    if kq_fn is not None:
+        _patch_make_mask()
     patched = 0
     for name in _MODULES:
         try:
@@ -94,7 +220,7 @@ def install_quantized_sdpa_mask_fix() -> bool:
         if getattr(cur, "_gmlx_qsdpa_fix", False):
             patched += 1
             continue
-        mod.quantized_scaled_dot_product_attention = _make_fixed(cur)
+        mod.quantized_scaled_dot_product_attention = _make_fixed(cur, kq_fn)
         patched += 1
     if not patched:
         return False

--- a/gmlx/quantized_sdpa_fix.py
+++ b/gmlx/quantized_sdpa_fix.py
@@ -79,6 +79,10 @@ def _kq_q8_route():
         import mlx_kquant as kq
     except ImportError:
         return None
+    # Metal-only kernel: on a cpu default device (--cpu runs, no-Metal
+    # hosts) the stock path is correct, so the route declines.
+    if mx.default_device().type != mx.DeviceType.gpu:
+        return None
     fn = getattr(kq, "sdpa_decode_gqa", None)
     doc = (getattr(fn, "__doc__", "") or "") if fn is not None else ""
     if "k_scales" not in doc or "starts" not in doc:

--- a/gmlx/upstream_seams.json
+++ b/gmlx/upstream_seams.json
@@ -46,6 +46,7 @@
   "mlx_vlm.models.base:quantized_scaled_dot_product_attention": "d7c6813bb1ee072de5d2c069c68d8a88488ba50d13d8576dbc8c6509ee8c77c1",
   "mlx_vlm.models.cache:ArraysCache": "44bf19bcfcbe2cca94608365febf370ba9b21c6d76e77ba66ffe35ffebd79ac9",
   "mlx_vlm.models.cache:BatchKVCache": "493076d3b5a091a8c33f40cef81ee34a2951b7ddd0024d278e82cef54087ac14",
+  "mlx_vlm.models.cache:BatchQuantizedKVCache.make_mask": "17cab343ff407f6c461bcd3cc94753c012d51a07863fe765ed46b9913211a525",
   "mlx_vlm.models.cache:BatchRotatingKVCache": "8c3bd92249b714d8d2227219c151d6ee108da5caa365bd179ab3d55aacd3ed01",
   "mlx_vlm.models.cache:BufferedRotatingKVCache": "623b327368125c0dba793507e92bf45665fcfb9b2fab1d21b24091f530c108c2",
   "mlx_vlm.models.cache:CacheList": "217e4ef653c66291bb34f84e065e16dbdd7771de47de2ee5b7abe5a35a9f9137",

--- a/gmlx/upstream_seams.py
+++ b/gmlx/upstream_seams.py
@@ -129,6 +129,9 @@ SEAMS: tuple[Seam, ...] = (
          "quantized_sdpa_fix (5D grouped scores vs 4D batch mask)"),
     Seam("mlx_vlm.models.base", "quantized_scaled_dot_product_attention",
          "quantized_sdpa_fix (same body as the mlx_lm copy)"),
+    Seam("mlx_vlm.models.cache", "BatchQuantizedKVCache.make_mask",
+         "quantized_sdpa_fix._patch_make_mask (starts registration for "
+         "the fused decode route; left_padding attr contract)"),
     # --- gemma4 text-only load path (mlx_lm module wrapped in text_only) ---
     Seam("mlx_lm.models.gemma4_text", "scaled_dot_product_attention",
          "gemma4_batched_sdpa (same row route at the text-only seam)"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # >=0.3.7: first release with a cp314 wheel. Below it, a Python 3.14
     # install (uv and pipx pick the newest interpreter by default) silently
     # falls back to compiling the Metal kernels from source.
-    "mlx-kquant>=0.3.7",
+    "mlx-kquant>=0.3.8",
     "mlx-lm>=0.31",
     # Direct imports of both throughout (mx.*, np.*); declared explicitly
     # rather than inherited through mlx-lm.

--- a/tests/test_quantized_sdpa_fix.py
+++ b/tests/test_quantized_sdpa_fix.py
@@ -186,7 +186,7 @@ def test_install_idempotent_and_killable(monkeypatch):
 
 needs_kq = pytest.mark.skipif(
     qf._kq_q8_route() is None,
-    reason="mlx_kquant build without q8+starts sdpa_decode_gqa")
+    reason="q8+starts sdpa_decode_gqa unavailable (build or cpu device)")
 
 
 def _spy_wrapper():

--- a/tests/test_quantized_sdpa_fix.py
+++ b/tests/test_quantized_sdpa_fix.py
@@ -3,7 +3,11 @@ scores vs a 4D batch mask raises a broadcast error when B != n_kv_heads
 and silently misapplies the mask (batch dim lands in the head slot) when
 B == n_kv_heads. The fix inserts one mask axis; these tests pin the raise
 repro, both numerics cases against a dequantized reference, the
-ungrouped/B=1 pass-through, and install hygiene.
+ungrouped/B=1 pass-through, and install hygiene. The same wrapper routes
+prefill-width calls (qL >= GMLX_KV8_PREFILL_FLASH_MIN_L) through
+dequant + fused flash SDPA; those tests pin numerics vs both the
+dequantized reference and the stock quantized body, the threshold, and
+the kill switch.
 
 Upstream mutates `queries` in place (`queries *= scale`), so every call
 here gets a fresh copy -- reusing one q across calls poisons comparisons.
@@ -95,6 +99,61 @@ def test_ungrouped_and_b1_pass_through():
     assert mx.abs(got - ref).max().item() == 0.0
     # B=1 grouped worked upstream already; fix must agree with it
     q, qk, qv, mask = _case(B=1, nq=8, nkv=4, pads=(3,))
+    got = lm_base.quantized_scaled_dot_product_attention(
+        mx.array(q), qk, qv, 0.125, mask)
+    ref = _orig_lm(mx.array(q), qk, qv, 0.125, mask)
+    assert mx.abs(got - ref).max().item() == 0.0
+
+
+def test_prefill_flash_matches_dequant_reference():
+    # qL >= MIN_L routes dequant+fused-flash; identical ops to _ref -> exact.
+    assert qf.install_quantized_sdpa_mask_fix()
+    q, qk, qv, mask = _case(B=2, nq=8, nkv=4, L=64, kv=256, pads=(5, 0))
+    got = lm_base.quantized_scaled_dot_product_attention(
+        mx.array(q), qk, qv, 0.125, mask)
+    assert mx.abs(got - _ref(q, qk, qv, mask)).max().item() == 0.0
+
+
+def test_prefill_flash_matches_stock_numerics():
+    # Cross-check the flash path against the stock quantized body (mask
+    # pre-expanded for the upstream 5D bug) at prefill width.
+    assert qf.install_quantized_sdpa_mask_fix()
+    q, qk, qv, mask = _case(B=2, nq=8, nkv=4, L=32, kv=256, pads=(5, 0))
+    got = lm_base.quantized_scaled_dot_product_attention(
+        mx.array(q), qk, qv, 0.125, mask)
+    stock = _orig_lm(mx.array(q), qk, qv, 0.125, mask[:, None])
+    err = mx.abs(got - stock).max().item()
+    assert err < 2e-2, f"flash vs stock err={err}"
+
+
+def test_prefill_flash_causal_str_mask():
+    assert qf.install_quantized_sdpa_mask_fix()
+    q, qk, qv, _ = _case(B=1, nq=8, nkv=4, L=16, kv=64)
+    got = lm_base.quantized_scaled_dot_product_attention(
+        mx.array(q), qk, qv, 0.125, "causal")
+    stock = _orig_lm(mx.array(q), qk, qv, 0.125, "causal")
+    err = mx.abs(got - stock).max().item()
+    assert err < 2e-2, f"causal flash vs stock err={err}"
+
+
+def test_prefill_flash_threshold_and_kill(monkeypatch):
+    assert qf.install_quantized_sdpa_mask_fix()
+    # below MIN_L: stock quantized path (compare exact vs orig)
+    q, qk, qv, mask = _case(B=1, nq=8, nkv=4, L=4, kv=64, pads=(3,))
+    got = lm_base.quantized_scaled_dot_product_attention(
+        mx.array(q), qk, qv, 0.125, mask)
+    ref = _orig_lm(mx.array(q), qk, qv, 0.125, mask)
+    assert mx.abs(got - ref).max().item() == 0.0
+    # raised threshold: prefill width falls back to stock
+    monkeypatch.setenv("GMLX_KV8_PREFILL_FLASH_MIN_L", "128")
+    q, qk, qv, mask = _case(B=1, nq=8, nkv=4, L=64, kv=256, pads=(3,))
+    got = lm_base.quantized_scaled_dot_product_attention(
+        mx.array(q), qk, qv, 0.125, mask)
+    ref = _orig_lm(mx.array(q), qk, qv, 0.125, mask)
+    assert mx.abs(got - ref).max().item() == 0.0
+    monkeypatch.delenv("GMLX_KV8_PREFILL_FLASH_MIN_L", raising=False)
+    # kill switch: flash off, stock path even at prefill width
+    monkeypatch.setenv("GMLX_KV8_PREFILL_FLASH", "0")
     got = lm_base.quantized_scaled_dot_product_attention(
         mx.array(q), qk, qv, 0.125, mask)
     ref = _orig_lm(mx.array(q), qk, qv, 0.125, mask)

--- a/tests/test_quantized_sdpa_fix.py
+++ b/tests/test_quantized_sdpa_fix.py
@@ -7,7 +7,10 @@ ungrouped/B=1 pass-through, and install hygiene. The same wrapper routes
 prefill-width calls (qL >= GMLX_KV8_PREFILL_FLASH_MIN_L) through
 dequant + fused flash SDPA; those tests pin numerics vs both the
 dequantized reference and the stock quantized body, the threshold, and
-the kill switch.
+the kill switch. Decode-width calls (qL == 1) route through the fused
+mlx_kquant kernel when its build carries q8 operands + starts; those
+tests pin the left-pad mask -> starts conversion, the non-left-pad and
+float-mask fallbacks, the identity memo, and the kill switch.
 
 Upstream mutates `queries` in place (`queries *= scale`), so every call
 here gets a fresh copy -- reusing one q across calls poisons comparisons.
@@ -33,11 +36,12 @@ def teardown_module(module):
     qf._installed = False
 
 
-def _case(B=2, nq=8, nkv=4, L=1, kv=64, d=64, pads=(5, 0)):
+def _case(B=2, nq=8, nkv=4, L=1, kv=64, d=64, pads=(5, 0),
+          dtype=mx.float32):
     mx.random.seed(11)
-    q = mx.random.normal((B, nq, L, d))
-    k = mx.random.normal((B, nkv, kv, d))
-    v = mx.random.normal((B, nkv, kv, d))
+    q = mx.random.normal((B, nq, L, d)).astype(dtype)
+    k = mx.random.normal((B, nkv, kv, d)).astype(dtype)
+    v = mx.random.normal((B, nkv, kv, d)).astype(dtype)
     qk = mx.quantize(k, group_size=64, bits=8)
     qv = mx.quantize(v, group_size=64, bits=8)
     pos = mx.arange(kv)[None, None, None, :]
@@ -89,7 +93,9 @@ def test_vlm_twin_fixed_too():
     assert err < 2e-2, f"vlm fixed numerics err={err}"
 
 
-def test_ungrouped_and_b1_pass_through():
+def test_ungrouped_and_b1_pass_through(monkeypatch):
+    # kq route off: this test pins the mask handling of the stock body.
+    monkeypatch.setenv("GMLX_QSDPA_KQ", "0")
     assert qf.install_quantized_sdpa_mask_fix()
     # no grouping (nq == nkv): wrapper must not change the mask
     q, qk, qv, mask = _case(B=2, nq=2, nkv=2)
@@ -176,3 +182,149 @@ def test_install_idempotent_and_killable(monkeypatch):
     assert qf.install_quantized_sdpa_mask_fix()
     assert lm_base.quantized_scaled_dot_product_attention is pl
     assert vlm_base.quantized_scaled_dot_product_attention is pv
+
+
+needs_kq = pytest.mark.skipif(
+    qf._kq_q8_route() is None,
+    reason="mlx_kquant build without q8+starts sdpa_decode_gqa")
+
+
+def _spy_wrapper():
+    """A wrapper built around the real kq route with call recording."""
+    real = qf._kq_q8_route()
+    calls = []
+
+    def spy(*a, **kw):
+        calls.append(kw.get("starts"))
+        return real(*a, **kw)
+
+    return qf._make_fixed(_orig_lm, spy), calls
+
+
+@needs_kq
+def test_kq_decode_route_registered_leftpad_mask():
+    # a REGISTERED boolean left-pad mask routes with its starts
+    fixed, calls = _spy_wrapper()
+    q, qk, qv, mask = _case(B=3, nq=8, nkv=4, kv=512, pads=(37, 5, 0),
+                            dtype=mx.float16)
+    qf._STARTS_MEMO.clear()
+    qf._register_starts(mask, mx.array([37, 5, 0]))
+    got = fixed(mx.array(q), qk, qv, 0.125, mask)
+    assert len(calls) == 1 and calls[0] is not None
+    assert calls[0].tolist() == [37, 5, 0]
+    err = mx.abs(got - _ref(q, qk, qv, mask)).max().item()
+    assert err < 2e-2, f"kq route vs dequant ref err={err}"
+    qf._STARTS_MEMO.clear()
+
+
+@needs_kq
+def test_make_mask_registers_and_routes():
+    # the real seam: BatchQuantizedKVCache.make_mask registers its mask,
+    # and a wire fetched from the same cache routes end to end
+    pytest.importorskip("mlx_vlm.models.cache")
+    from mlx_vlm.models import cache as vcache
+
+    assert qf._patch_make_mask()
+    assert vcache.BatchQuantizedKVCache.make_mask._gmlx_starts_reg
+    qf._STARTS_MEMO.clear()
+    mx.random.seed(11)
+    pads = [37, 5, 0]
+    c = vcache.BatchQuantizedKVCache(pads, group_size=64, bits=8)
+    k = mx.random.normal((3, 4, 511, 64)).astype(mx.float16)
+    v = mx.random.normal((3, 4, 511, 64)).astype(mx.float16)
+    c.update_and_fetch(k, v)
+    # per-step order: mask first (anticipates the new token), then update
+    mask = c.make_mask(1)
+    qk, qv = c.update_and_fetch(
+        mx.random.normal((3, 4, 1, 64)).astype(mx.float16),
+        mx.random.normal((3, 4, 1, 64)).astype(mx.float16))
+    ent = qf._STARTS_MEMO.get(id(mask))
+    assert ent is not None and ent[0] is mask
+    assert ent[1].tolist() == pads and ent[1].dtype == mx.int32
+    # windowed masks are NOT registered
+    wmask = c.make_mask(1, window_size=64)
+    assert qf._registered_starts(wmask) is None
+
+    fixed, calls = _spy_wrapper()
+    q = mx.random.normal((3, 8, 1, 64)).astype(mx.float16)
+    got = fixed(mx.array(q), qk, qv, 0.125, mask)
+    assert len(calls) == 1 and calls[0].tolist() == pads
+    err = mx.abs(got - _ref(q, qk, qv, mask)).max().item()
+    assert err < 2e-2, f"seam route vs dequant ref err={err}"
+    qf._STARTS_MEMO.clear()
+
+
+@needs_kq
+def test_kq_decode_route_maskless_and_causal():
+    fixed, calls = _spy_wrapper()
+    q, qk, qv, _ = _case(B=2, nq=8, nkv=4, kv=256, dtype=mx.float16)
+    got = fixed(mx.array(q), qk, qv, 0.125, None)
+    got_c = fixed(mx.array(q), qk, qv, 0.125, "causal")
+    assert len(calls) == 2 and calls[0] is None and calls[1] is None
+    full = mx.ones((2, 1, 1, 256), dtype=mx.bool_)
+    err = mx.abs(got - _ref(q, qk, qv, full)).max().item()
+    assert err < 2e-2, f"maskless route err={err}"
+    assert mx.abs(got_c - got).max().item() == 0.0
+
+
+@needs_kq
+def test_kq_decode_route_fallbacks():
+    fixed, calls = _spy_wrapper()
+    q, qk, qv, mask = _case(B=2, nq=8, nkv=4, kv=256, pads=(9, 0),
+                            dtype=mx.float16)
+    # UNREGISTERED boolean mask (unknown provenance) -> stock body, exact
+    qf._STARTS_MEMO.clear()
+    got = fixed(mx.array(q), qk, qv, 0.125, mask)
+    ref = _orig_lm(mx.array(q), qk, qv, 0.125, mask[:, None])
+    assert not calls
+    assert mx.abs(got - ref).max().item() == 0.0
+    # additive float mask -> stock body, exact
+    fmask = mx.where(mask, mx.array(0.0, mx.float16),
+                     mx.array(-mx.inf, mx.float16))
+    got = fixed(mx.array(q), qk, qv, 0.125, fmask)
+    ref = _orig_lm(mx.array(q), qk, qv, 0.125, fmask[:, None])
+    assert not calls
+    assert mx.abs(got - ref).max().item() == 0.0
+    # fp32 queries -> stock body
+    q32, qk32, qv32, m32 = _case(B=2, nq=8, nkv=4, kv=256, pads=(9, 0))
+    got = fixed(mx.array(q32), qk32, qv32, 0.125, m32)
+    ref = _orig_lm(mx.array(q32), qk32, qv32, 0.125, m32[:, None])
+    assert not calls
+    assert mx.abs(got - ref).max().item() == 0.0
+
+
+@needs_kq
+def test_kq_decode_route_kill_switch(monkeypatch):
+    fixed, calls = _spy_wrapper()
+    q, qk, qv, mask = _case(B=2, nq=8, nkv=4, kv=256, pads=(9, 0),
+                            dtype=mx.float16)
+    qf._STARTS_MEMO.clear()
+    qf._register_starts(mask, mx.array([9, 0]))
+    monkeypatch.setenv("GMLX_QSDPA_KQ", "0")
+    got = fixed(mx.array(q), qk, qv, 0.125, mask)
+    ref = _orig_lm(mx.array(q), qk, qv, 0.125, mask[:, None])
+    assert not calls
+    assert mx.abs(got - ref).max().item() == 0.0
+    monkeypatch.delenv("GMLX_QSDPA_KQ", raising=False)
+    fixed(mx.array(q), qk, qv, 0.125, mask)
+    assert len(calls) == 1
+    qf._STARTS_MEMO.clear()
+
+
+def test_starts_registry_identity_and_cap():
+    qf._STARTS_MEMO.clear()
+    pos = mx.arange(64)[None, None, None, :]
+    mask = pos >= mx.array([7, 0])[:, None, None, None]
+    qf._register_starts(mask, mx.array([7, 0]))
+    a = qf._registered_starts(mask)
+    b = qf._registered_starts(mask)
+    assert a is b and a.tolist() == [7, 0] and a.dtype == mx.int32
+    assert len(qf._STARTS_MEMO) == 1
+    # unregistered object -> None, even with identical contents
+    twin = pos >= mx.array([7, 0])[:, None, None, None]
+    assert qf._registered_starts(twin) is None
+    for i in range(qf._STARTS_MEMO_CAP + 2):
+        m = pos >= mx.array([i, 0])[:, None, None, None]
+        qf._register_starts(m, mx.array([i, 0]))
+    assert len(qf._STARTS_MEMO) == qf._STARTS_MEMO_CAP
+    qf._STARTS_MEMO.clear()


### PR DESCRIPTION
- bumps mlx-kquant >= 0.3.8